### PR TITLE
feat: Adds ModuleIncludedTwice Rule and test

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/ModuleIncludedTwiceRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/ModuleIncludedTwiceRule.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nextflow.rules
+
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.util.AstUtil
+
+/**
+ * Checks if a module has been included twice, with or without an alias
+ */
+class ModuleIncludedTwiceRule extends AbstractAstVisitorRule{
+    String name = 'ModuleIncludedTwiceRule'
+    int priority = 2
+    Class astVisitorClass = ModuleIncludedTwiceAstVisitor
+}
+
+class ModuleIncludedTwiceAstVisitor extends AbstractAstVisitor {
+
+    Map<String, Set<String>> pathsAndModules = [:]
+    boolean withinInclude
+    String path
+    Set<String> modules = []
+
+    @Override
+    void visitMethodCallExpression(MethodCallExpression call) {
+        String methodName = call.methodAsString
+        if (methodName == "include") {
+            withinInclude = true
+        }
+
+        if (methodName == "from") {
+            for (arg in AstUtil.getMethodArguments(call)) {
+                path = arg.text
+            }
+        }
+        super.visitMethodCallExpression(call)
+        withinInclude = false
+        path = null
+        modules = []
+    }
+
+    @Override
+    void visitVariableExpression(VariableExpression expression) {
+        if (withinInclude && expression.text != 'this') {
+
+            if (pathsAndModules.containsKey(path)) {
+                if (pathsAndModules.get(path).contains(expression.text)) {
+                    addViolation(expression, "include with same module and path declared twice")
+                } else {
+                    pathsAndModules.get(path).add(expression.text)
+                }
+            } else {
+                modules.add(expression.text)
+                pathsAndModules.put(path, modules)
+            }
+        }
+        super.visitVariableExpression(expression)
+    }
+
+}

--- a/linter-rules/src/main/resources/rulesets/general.xml
+++ b/linter-rules/src/main/resources/rulesets/general.xml
@@ -1,0 +1,15 @@
+<!--
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+-->
+<ruleset xmlns="http://codenarc.org/ruleset/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd">
+    <description>
+        Rules that detect Nextflow constructs that are likely to cause problems when run in AWS HealthOmics workflows.
+    </description>
+
+    <!-- Nextflow rules -->
+    <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
+    <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
+</ruleset>

--- a/linter-rules/src/main/resources/rulesets/healthomics.xml
+++ b/linter-rules/src/main/resources/rulesets/healthomics.xml
@@ -11,6 +11,7 @@
 
     <!-- Nextflow rules -->
     <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
+    <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
 
     <!-- Nextflow on HealthOmics rules -->
     <rule class="software.amazon.nextflow.rules.healthomics.AllowedHealthOmicsDirectivesRule"/>

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/ModuleIncludedTwiceRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/ModuleIncludedTwiceRuleTest.groovy
@@ -1,0 +1,69 @@
+package software.amazon.nextflow.rules
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.junit.jupiter.api.Test
+
+class ModuleIncludedTwiceRuleTest extends AbstractRuleTestCase<ModuleIncludedTwiceRule> {
+    protected ModuleIncludedTwiceRule createRule(){
+        return new ModuleIncludedTwiceRule()
+    }
+
+    @Test
+    void ruleProperties(){
+        assert rule.name == 'ModuleIncludedTwiceRule'
+        assert rule.priority == 2
+    }
+
+    @Test
+    void moduleIncludedTwice_Violation(){
+        final SOURCE=
+'''
+include { TOOL } from 'my/path/tool/main'
+include { TOOL as TOOL_2 } from 'my/path/tool/main'
+'''
+        assertSingleViolation(
+                SOURCE,
+                3,
+                "include { TOOL as TOOL_2 } from 'my/path/tool/main'",
+                "include with same module and path declared twice"
+        )
+    }
+
+    @Test
+    void oneInclude_NoViolation(){
+        final SOURCE=
+                '''
+include { TOOL } from 'my/path/tool/main'
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void differentPaths_NoViolation(){
+        final SOURCE=
+                '''
+include { TOOL } from 'my/path/tool/main'
+include { TOOL as TOOL_2 } from 'different/path/tool/main'
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void moduleIncludedThrice_Violation(){
+        final SOURCE=
+                '''
+include { TOOL } from 'my/path/tool/main'
+include { TOOL as TOOL_2 } from 'my/path/tool/main'
+include { TOOL as TOOL_3 } from 'my/path/tool/main'
+'''
+        assertTwoViolations(
+                SOURCE,
+                3,
+                "include { TOOL as TOOL_2 } from 'my/path/tool/main'",
+                "include with same module and path declared twice",
+                4,
+                "include { TOOL as TOOL_3 } from 'my/path/tool/main'",
+                "include with same module and path declared twice"
+        )
+    }
+}


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Adds a rule that detects if a module is `include`d twice with the same path even if an alias is used (redundant include).

**Description of how you validated changes**

Included test class, tests passing


**Checklist**

- [x] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*