### PR TITLE
fix: fixes many false positives with detecting disallowed process directives.

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/utils/NFUtils.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/utils/NFUtils.groovy
@@ -11,7 +11,7 @@ class NFUtils {
             'containerOptions', 'cpus', 'debug', 'disk', 'echo', 'errorStrategy', 'executor', /*'ext'*/ 'fair', 'label',
             'machineType', 'maxSubmitAwait', 'maxErrors', 'maxForks', 'maxRetries', 'memory', 'module', 'penv', 'pod',
             'publishDir', 'queue', 'resourceLabels', 'scratch', 'shell', 'spack', 'stageInMode', 'stageOutMode', 'storeDir',
-            'tag', 'time'
+            'tag', 'time', 'template'
     ]
 
     def static ALLOWED_NF_INPUTS_DIRECTIVES = [

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/AllowedDirectivesRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/AllowedDirectivesRuleTest.groovy
@@ -593,4 +593,47 @@ process big_job {
 '''
         assertNoViolations(SOURCE)
     }
+
+    @Test
+    void ifStatements_NoViolations(){
+        final SOURCE = '''
+process FASTP {
+    script:
+    if ( task.ext.args?.contains('--interleaved_in') ) {
+        """
+        command
+        """
+    } else if (meta.single_end) {
+        """
+        command
+        """
+    } else {
+        def merge_fastq = save_merged ? "-m --merged_out ${prefix}.merged.fastq.gz" : ''
+        """
+        command
+        """
+    }
+}
+
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void templateScript_NoViolations() {
+        final SOURCE = '''
+process templateExample {
+    input:
+    val STR
+
+    script:
+    template 'my_script.sh'
+}
+
+workflow {
+    Channel.of('this', 'that') | templateExample
+}
+'''
+        assertNoViolations(SOURCE)
+    }
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

False positives occurred in chained method calls and method calls inside of if statements

**Description of how you validated changes**

Updated unit test cases with more complex examples


**Checklist**

- [ ] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*