### PR TITLE
Adds the ability to configure/ switch rulesets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN wget https://repo1.maven.org/maven2/org/codenarc/CodeNarc/3.3.0/CodeNarc-3.3
     wget https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar && \
     wget https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
 
-CMD bash check.sh
+ENV ruleset "healthomics"
+ENTRYPOINT bash check.sh ${ruleset}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Here we have configured CodeNarc to use the rules in `rulesets/healthomics.xml` 
 contained in this libraries JAR file. The `-includes` parameter takes an Ant style pattern. This pattern will inspect
 all `*.nf` files at the current location and in subdirectories.
 
+### General NF Rules only
+If you only wish to check general Nextflow lint rules and not include those specialized to AWS HealthOmics then you can
+run:
+
+```shell
+java  -Dorg.slf4j.simpleLogger.defaultLogLevel=error \
+  -classpath ./linter-rules/build/libs/linter-rules-0.1.jar:CodeNarc-3.3.0-all.jar:slf4j-api-1.7.36.jar:slf4j-simple-1.7.36.jar \
+  org.codenarc.CodeNarc \
+  -report=text:stdout \
+  -rulesetfiles=rulesets/general.xml \
+  -includes=**/**.nf
+```
+
 ### Docker
 
 A `Dockerfile` is provided for this project which will build an image that contains the scripts in `scripts/` and the
@@ -95,6 +108,18 @@ File: example.nf
 [CodeNarc (https://codenarc.org) v3.3.0]
 CodeNarc completed: (p1=3; p2=0; p3=0) 1757ms
 ```
+
+#### General Rules Only
+
+If you only want to check the general rules using the container you can set the `ruleset` environment variable to `general`
+as follows:
+
+```shell
+cd examples
+docker run -v $PWD:/data -e ruleset=general linter-rules-for-nextflow
+```
+
+#### AST Echo
 
 The container also contains the `ast-echo` application along with a script to run it (`echo-tree.sh`). For example:
 
@@ -227,8 +252,9 @@ To run a specific test method in a test class:
 
 ### Update the Ruleset
 
-When a rule is created it should be added to the `resources/rulesets/healthomics.xml` file. Entries use the fully 
-qualified class name of the rule. Assuming the new Rule is called `NewRule` and the package is 
+When a rule is created it should be added to the `linter-rules/src/resources/rulesets/healthomics.xml` file. If the rule is general to any
+Nextflow environment then it should **also** be added to the `linter-rules/src/resources/rulesets/general.xml`
+Entries use the fully qualified class name of the rule. Assuming the new Rule is called `NewRule` and the package is 
 `software.amazon.nextflow.rules.healthomics`, the rule to be added will be:
 
 ```xml

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,9 +1,12 @@
 #! /bin/bash
 
+RULESET="$1"
+echo  "Checking with ruleset: ${RULESET:=healthomics}"
+
 java  -Dorg.slf4j.simpleLogger.defaultLogLevel=error \
   -classpath linter-rules.jar:CodeNarc-3.3.0-all.jar:slf4j-api-1.7.36.jar:slf4j-simple-1.7.36.jar \
   org.codenarc.CodeNarc \
   -report=text:stdout \
-  -rulesetfiles=rulesets/healthomics.xml \
+  -rulesetfiles=rulesets/"${RULESET}".xml \
   -basedir=/data \
   -includes=**/*.nf


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

add the ability to switch rulesets when using the run script or the docker container

**Description of how you validated changes**
Compare outputs of 
```
docker run -v $PWD:/data -e ruleset=general nf-lint
```

and

```
docker run -v $PWD:/data nf-lint
```

**Checklist**

- [ ] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*