### PR TITLE
feat: Adds a rule to warn if join statements don't contain failOnMismatch a…

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/JoinMismatchRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/JoinMismatchRule.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nextflow.rules
+
+import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.ast.expr.MapEntryExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.util.AstUtil
+
+/**
+ * Checks if a module has been included twice, with or without an alias
+ */
+class JoinMismatchRule extends AbstractAstVisitorRule{
+    String name = 'JoinMismatchRule'
+    int priority = 3
+    Class astVisitorClass = JoinMismatchAstVisitor
+}
+
+class JoinMismatchAstVisitor extends AbstractAstVisitor {
+    var inJoinMethod = false
+    var failOnMismatchFound = false
+
+    @Override
+    void visitMethodCallExpression(MethodCallExpression call) {
+        String methodName = call.methodAsString
+        if (methodName == "join") {
+            inJoinMethod = true
+        }
+
+        super.visitMethodCallExpression(call)
+
+        if (inJoinMethod && !failOnMismatchFound) {
+            addViolation(call, "A join will silently discard mismatched items. Use 'failOnMismatch' argument to make your intention explicit." )
+        }
+
+        inJoinMethod = false
+        failOnMismatchFound = false
+    }
+
+    @Override
+    void visitMapEntryExpression(MapEntryExpression expression) {
+
+        if (inJoinMethod &&  expression.keyExpression.text == "failOnMismatch") {
+            failOnMismatchFound = true
+        }
+
+        super.visitMapEntryExpression(expression)
+    }
+}

--- a/linter-rules/src/main/resources/rulesets/general.xml
+++ b/linter-rules/src/main/resources/rulesets/general.xml
@@ -12,4 +12,5 @@
     <!-- Nextflow rules -->
     <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
     <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
+    <rule class="software.amazon.nextflow.rules.JoinMismatchRule"/>
 </ruleset>

--- a/linter-rules/src/main/resources/rulesets/healthomics.xml
+++ b/linter-rules/src/main/resources/rulesets/healthomics.xml
@@ -12,6 +12,8 @@
     <!-- Nextflow rules -->
     <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
     <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
+    <rule class="software.amazon.nextflow.rules.JoinMismatchRule"/>
+
 
     <!-- Nextflow on HealthOmics rules -->
     <rule class="software.amazon.nextflow.rules.healthomics.AllowedHealthOmicsDirectivesRule"/>

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/JoinMismatchRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/JoinMismatchRuleTest.groovy
@@ -1,0 +1,72 @@
+package software.amazon.nextflow.rules
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.junit.jupiter.api.Test
+
+class JoinMismatchRuleTest extends AbstractRuleTestCase<JoinMismatchRule> {
+    protected JoinMismatchRule createRule() {
+        return new JoinMismatchRule()
+    }
+
+    @Test
+    void ruleProperties() {
+        assert rule.name == "JoinMismatchRule"
+        assert rule.priority == 3
+    }
+
+    @Test
+    void joinWithMismatchArg_NoViolation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right, failOnMismatch: true)
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void joinWithMismatchArgFalse_NoViolation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right, failOnMismatch: false)
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void joinWithoutMismatchArg_Violation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right)
+'''
+        assertSingleViolation(SOURCE,
+                        5,
+                        "ch_joined = left.join(right)",
+                        "A join will silently discard mismatched items. Use 'failOnMismatch' argument to make your intention explicit."
+        )
+    }
+
+    @Test
+    void joinWithoutMismatchTwice_Violation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right)
+ch_joined2 = right.join(left, failOnDuplicate: false)
+'''
+        assertTwoViolations(SOURCE,
+                5,
+                "ch_joined = left.join(right)",
+                "A join will silently discard mismatched items. Use 'failOnMismatch' argument to make your intention explicit.",
+                6,
+                "ch_joined2 = right.join(left, failOnDuplicate: false)",
+                "A join will silently discard mismatched items. Use 'failOnMismatch' argument to make your intention explicit."
+        )
+    }
+}


### PR DESCRIPTION
…rgument

<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

will warn if a `baa.join(foo)` call is made without a `failOnMismatch` parameter. This is because unmatched pairs will be silently discarded which unless intended can make debugging difficult.

**Description of how you validated changes**

Added unit test


**Checklist**

- [x] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*