### PR TITLE
feat: Adds a rule to warn if join statements don't contain failOnDuplicate

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/JoinDuplicateRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/JoinDuplicateRule.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nextflow.rules
+
+
+import org.codehaus.groovy.ast.expr.MapEntryExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+
+/**
+ * Checks if a module has been included twice, with or without an alias
+ */
+class JoinDuplicateRule extends AbstractAstVisitorRule{
+    String name = 'JoinDuplicateRule'
+    int priority = 3
+    Class astVisitorClass = JoinDuplicateAstVisitor
+}
+
+class JoinDuplicateAstVisitor extends AbstractAstVisitor {
+    var inJoinMethod = false
+    var failOnDuplicateFound = false
+
+    @Override
+    void visitMethodCallExpression(MethodCallExpression call) {
+        String methodName = call.methodAsString
+        if (methodName == "join") {
+            inJoinMethod = true
+        }
+
+        super.visitMethodCallExpression(call)
+
+        if (inJoinMethod && !failOnDuplicateFound) {
+            addViolation(call, "The join doesn't explicitly define a strategy for duplicates. Recommend adding a 'failOnDuplicate' argument." )
+        }
+
+        inJoinMethod = false
+        failOnDuplicateFound = false
+    }
+
+    @Override
+    void visitMapEntryExpression(MapEntryExpression expression) {
+
+        if (inJoinMethod &&  expression.keyExpression.text == "failOnDuplicate") {
+            failOnDuplicateFound = true
+        }
+
+        super.visitMapEntryExpression(expression)
+    }
+}

--- a/linter-rules/src/main/resources/rulesets/general.xml
+++ b/linter-rules/src/main/resources/rulesets/general.xml
@@ -13,4 +13,5 @@
     <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
     <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
     <rule class="software.amazon.nextflow.rules.JoinMismatchRule"/>
+    <rule class="software.amazon.nextflow.rules.JoinDuplicateRule"/>
 </ruleset>

--- a/linter-rules/src/main/resources/rulesets/healthomics.xml
+++ b/linter-rules/src/main/resources/rulesets/healthomics.xml
@@ -13,7 +13,7 @@
     <rule class="software.amazon.nextflow.rules.AllowedDirectivesRule"/>
     <rule class="software.amazon.nextflow.rules.ModuleIncludedTwiceRule"/>
     <rule class="software.amazon.nextflow.rules.JoinMismatchRule"/>
-
+    <rule class="software.amazon.nextflow.rules.JoinDuplicateRule"/>
 
     <!-- Nextflow on HealthOmics rules -->
     <rule class="software.amazon.nextflow.rules.healthomics.AllowedHealthOmicsDirectivesRule"/>

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/JoinDuplicateRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/JoinDuplicateRuleTest.groovy
@@ -1,0 +1,72 @@
+package software.amazon.nextflow.rules
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.junit.jupiter.api.Test
+
+class JoinDuplicateRuleTest extends AbstractRuleTestCase<JoinDuplicateRule> {
+    protected JoinDuplicateRule createRule() {
+        return new JoinDuplicateRule()
+    }
+
+    @Test
+    void ruleProperties() {
+        assert rule.name == "JoinDuplicateRule"
+        assert rule.priority == 3
+    }
+
+    @Test
+    void joinWithDuplicateArg_NoViolation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right, failOnMismatch: true, failOnDuplicate: true)
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void joinWithDuplicateArgFalse_NoViolation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right, failOnDuplicate: false)
+'''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void joinWithoutMismatchArg_Violation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right)
+'''
+        assertSingleViolation(SOURCE,
+                        5,
+                        "ch_joined = left.join(right)",
+                        "The join doesn't explicitly define a strategy for duplicates. Recommend adding a 'failOnDuplicate' argument."
+        )
+    }
+
+    @Test
+    void joinWithoutMismatchTwice_Violation() {
+        final SOURCE = '''
+left = LEFT(ch_param)
+right = RIGHT(ch_param)
+
+ch_joined = left.join(right)
+ch_joined2 = right.join(left, failOnMismatch: false)
+'''
+        assertTwoViolations(SOURCE,
+                5,
+                "ch_joined = left.join(right)",
+                "The join doesn't explicitly define a strategy for duplicates. Recommend adding a 'failOnDuplicate' argument.",
+                6,
+                "ch_joined2 = right.join(left, failOnMismatch: false)",
+                "The join doesn't explicitly define a strategy for duplicates. Recommend adding a 'failOnDuplicate' argument."
+        )
+    }
+}


### PR DESCRIPTION

<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Adds a rule to warn if join statements don't contain failOnDuplicate argument. Duplicates in a channel are often an indication of a bug in upstream logic, generally it would be advisable to fail on duplicates during a join.

**Description of how you validated changes**

Added unit tests


**Checklist**

- [x] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*