### PR TITLE
feat: Re-enable 'ext' process directive

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/utils/NFUtils.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/utils/NFUtils.groovy
@@ -8,7 +8,7 @@ package software.amazon.nextflow.rules.utils
 class NFUtils {
     def static ALLOWED_NF_PROCESS_DIRECTIVES = [
             'accelerator', 'afterScript', 'arch', 'beforeScript', 'cache', 'clusterOptions', 'conda', 'container',
-            'containerOptions', 'cpus', 'debug', 'disk', 'echo', 'errorStrategy', 'executor', /*'ext'*/ 'fair', 'label',
+            'containerOptions', 'cpus', 'debug', 'disk', 'echo', 'errorStrategy', 'executor', 'ext', 'fair', 'label',
             'machineType', 'maxSubmitAwait', 'maxErrors', 'maxForks', 'maxRetries', 'memory', 'module', 'penv', 'pod',
             'publishDir', 'queue', 'resourceLabels', 'scratch', 'shell', 'spack', 'stageInMode', 'stageOutMode', 'storeDir',
             'tag', 'time', 'template'


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

This re-enables the [ext](https://www.nextflow.io/docs/latest/process.html#ext) as an allowed process directive.

Support for `ext` was quietly commented out a few months back: https://github.com/awslabs/linter-rules-for-nextflow/commit/f179724123dee1bce3c73ab7f8aec4d3fba334e0#diff-6a2cdf2459bb3c14d53f1b673fb93512d5c00a0e79b8dacde7bfc90ba9f34474R6. I couldn't find any justification for why that was done, so I'm blindly opening this PR - no hard feelings here if there was a good reason!

**Description of how you validated changes**

I added a `./gradlew test` line to the Dockerfile and successfully ran `docker build .`.

```diff
$ git diff
diff --git a/Dockerfile b/Dockerfile
index 62d2fae..271b4e4 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . ./src

 WORKDIR /work/src
 RUN ./gradlew clean build
+RUN ./gradlew test
 WORKDIR /work

 RUN cp src/ast-echo/build/libs/ast-echo-*.jar ./ast-echo-all.jar && \
```


**Checklist**

- [ ] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [x] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*