### PR TITLE
feat: Add a rule to ensure path directives are S3 URIs

### DIFF
--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
@@ -1,45 +1,59 @@
 package software.amazon.nextflow.rules.healthomics
 
 import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.PropertyExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression                                                                               
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.util.AstUtil
+
 
 /*
  * Checks that the URI of the input file matches the s3 URI pattern
  *
  * @author Jesse Marks
  */
-class InputS3FileRule extends AbstractAstVisitorRule {
 
+class InputS3FileRule extends AbstractAstVisitorRule {
     String name = 'InputFileIsS3'
     int priority = 1
     Class astVisitorClass = InputS3FileAstVisitor
 }
 
 class InputS3FileAstVisitor extends AbstractAstVisitor {
-
     final String FILE_PATTERN = "s3://.*"
-
     @Override
-    void visitMethodCallExpression(MethodCallExpression expression){
-        if (expression.getMethod().getText() == "path") {
-
-            def methodArguments = AstUtil.getMethodArguments(expression)
-
-            // check that it is an "s3://" URI
-            if (methodArguments.size() == 1) {
-                final argExpression = methodArguments.get(0)
-                final arg = methodArguments.get(0).getText()
-
-                if (AstUtil.isConstantOrLiteral(argExpression) && !arg.matches(FILE_PATTERN)) {
-
-                    addViolation(expression, "The file path URI '$arg' does not match the pattern '$FILE_PATTERN'. Replace with a file located on s3.")
-                }
-            }
+    void visitMethodCallExpression(MethodCallExpression expression) {
+        if (expression.getMethodAsString() == "path") {
+            checkArguments(expression)
         }
-
-
-        super.visitMethodCallExpression(expression)
+        super .visitMethodCallExpression(expression)
+    }
+    private checkArguments(final MethodCallExpression expression) {
+        def methodArguments = AstUtil.getMethodArguments(expression)
+        if (methodArguments.size() != 1) {
+            addViolation(expression, 'The path directive must have exactly one argument.')
+        }
+        def fpath = methodArguments.first()
+        switch (fpath) {
+            case ConstantExpression:
+            checkFilePath(fpath as ConstantExpression)
+            break case PropertyExpression:
+            checkFilePathParam(fpath as PropertyExpression)
+            break default :
+            addViolation(expression, 'Invalid fpath')
+        }
+    }
+    private void checkFilePath(ConstantExpression expression) {
+        def arg = expression.value
+        if (!arg.matches(FILE_PATTERN)) {
+            addViolation(expression, "The file path '$arg' does not match the pattern '$FILE_PATTERN'. Replace with an S3 object URI.")
+        }
+    }
+    private void checkFilePathParam(PropertyExpression expression) {
+        def arg = expression.getObjectExpression().getText()
+        if (!arg.contains('params')) {
+            addViolation(expression, "The file path must be either a string or params.")
+        }
     }
 }

--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
@@ -1,12 +1,12 @@
 package software.amazon.nextflow.rules.healthomics
 
 import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
 import org.codehaus.groovy.ast.expr.PropertyExpression
-import org.codehaus.groovy.ast.expr.ConstantExpression                                                                               
+import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.util.AstUtil
-
 
 /*
  * Checks that the URI of the input file matches the s3 URI pattern
@@ -15,12 +15,15 @@ import org.codenarc.util.AstUtil
  */
 
 class InputS3FileRule extends AbstractAstVisitorRule {
+
     String name = 'InputFileIsS3'
     int priority = 1
     Class astVisitorClass = InputS3FileAstVisitor
+
 }
 
 class InputS3FileAstVisitor extends AbstractAstVisitor {
+
     final String FILE_PATTERN = "s3://.*"
     @Override
     void visitMethodCallExpression(MethodCallExpression expression) {
@@ -31,29 +34,27 @@ class InputS3FileAstVisitor extends AbstractAstVisitor {
     }
     private checkArguments(final MethodCallExpression expression) {
         def methodArguments = AstUtil.getMethodArguments(expression)
-        if (methodArguments.size() != 1) {
-            addViolation(expression, 'The path directive must have exactly one argument.')
-        }
-        def fpath = methodArguments.first()
-        switch (fpath) {
-            case ConstantExpression:
-            checkFilePath(fpath as ConstantExpression)
-            break case PropertyExpression:
-            checkFilePathParam(fpath as PropertyExpression)
-            break default :
-            addViolation(expression, 'Invalid fpath')
+        if (methodArguments.size() == 1) {
+            def fpath = methodArguments.first()
+            switch (fpath) {
+                case ConstantExpression:
+                    checkFilePath(fpath as ConstantExpression) // check literals
+                    break
+                case PropertyExpression:
+                    break // skip property expressions
+                case VariableExpression:
+                    break // skip variable expressions
+                default:
+                    addViolation(expression, 'Invalid path')
+            }
         }
     }
     private void checkFilePath(ConstantExpression expression) {
         def arg = expression.value
-        if (!arg.matches(FILE_PATTERN)) {
+        // fail if not an s3 path AND literal doesn't contain a variable
+        if (!arg.matches(FILE_PATTERN) && !arg.matches('.*\\$\\{[^}]+\\}.*')) {
             addViolation(expression, "The file path '$arg' does not match the pattern '$FILE_PATTERN'. Replace with an S3 object URI.")
         }
     }
-    private void checkFilePathParam(PropertyExpression expression) {
-        def arg = expression.getObjectExpression().getText()
-        if (!arg.contains('params')) {
-            addViolation(expression, "The file path must be either a string or params.")
-        }
-    }
+
 }

--- a/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
+++ b/linter-rules/src/main/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRule.groovy
@@ -1,0 +1,45 @@
+package software.amazon.nextflow.rules.healthomics
+
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.util.AstUtil
+
+/*
+ * Checks that the URI of the input file matches the s3 URI pattern
+ *
+ * @author Jesse Marks
+ */
+class InputS3FileRule extends AbstractAstVisitorRule {
+
+    String name = 'InputFileIsS3'
+    int priority = 1
+    Class astVisitorClass = InputS3FileAstVisitor
+}
+
+class InputS3FileAstVisitor extends AbstractAstVisitor {
+
+    final String FILE_PATTERN = "s3://.*"
+
+    @Override
+    void visitMethodCallExpression(MethodCallExpression expression){
+        if (expression.getMethod().getText() == "path") {
+
+            def methodArguments = AstUtil.getMethodArguments(expression)
+
+            // check that it is an "s3://" URI
+            if (methodArguments.size() == 1) {
+                final argExpression = methodArguments.get(0)
+                final arg = methodArguments.get(0).getText()
+
+                if (AstUtil.isConstantOrLiteral(argExpression) && !arg.matches(FILE_PATTERN)) {
+
+                    addViolation(expression, "The file path URI '$arg' does not match the pattern '$FILE_PATTERN'. Replace with a file located on s3.")
+                }
+            }
+        }
+
+
+        super.visitMethodCallExpression(expression)
+    }
+}

--- a/linter-rules/src/main/resources/rulesets/healthomics.xml
+++ b/linter-rules/src/main/resources/rulesets/healthomics.xml
@@ -31,5 +31,6 @@
     <rule class="software.amazon.nextflow.rules.healthomics.MissingProcessDirectivesRule"/>
     <rule class="software.amazon.nextflow.rules.healthomics.PublishDirRule"/>
     <rule class="software.amazon.nextflow.rules.healthomics.GpuRule"/>
+    <rule class="software.amazon.nextflow.rules.healthomics.InputS3FileRule"/>
     
 </ruleset>

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRuleTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.nextflow.rules.healthomics
+
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.junit.jupiter.api.Test
+
+/*
+ * Tests for InputFileIsS3Rule
+ *
+ * @author Jesse Marks
+ */
+
+class InputS3FileRuleTest extends AbstractRuleTestCase<InputS3FileRule> {
+
+    @Override                                                                                                                           
+    protected InputS3FileRule createRule() {                                                                                                    
+        new InputS3FileRule()                                                                                                                   
+    }                                                                                                                                   
+           
+    @Test
+    void RuleProperties() {
+        assert rule.priority == 1
+        assert rule.name == 'InputFileIsS3'
+    }
+
+    @Test
+    void filePath_NoViolations() {
+       final SOURCE = '''
+            params {
+                publishDir = "s3://my-output-bucket/results"
+            }
+
+            process processData {
+                publishDir params.publishDir
+                cpus 1
+
+                input:
+                path "s3://my-input-bucket/data/input1.txt"
+                path "s3://my-input-bucket/data/input2.txt"
+
+
+                """
+                echo "All input files are valid S3 paths."
+                """
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void filePath_OneViolation() {
+       final SOURCE = '''
+
+            process foo {
+                input:
+                path '/home/data/input1.txt'
+            }
+        '''
+        assertSingleViolation(SOURCE, 5, "path '/home/data/input1.txt'", "The file path URI '/home/data/input1.txt' does not match the pattern 's3://.*'. Replace with a file located on s3.")
+    }
+}

--- a/linter-rules/src/test/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRuleTest.groovy
+++ b/linter-rules/src/test/groovy/software/amazon/nextflow/rules/healthomics/InputS3FileRuleTest.groovy
@@ -31,18 +31,12 @@ class InputS3FileRuleTest extends AbstractRuleTestCase<InputS3FileRule> {
     @Test
     void filePath_NoViolations() {
        final SOURCE = '''
-            params {
-                publishDir = "s3://my-output-bucket/results"
-            }
 
             process processData {
-                publishDir params.publishDir
-                cpus 1
 
                 input:
-                path "s3://my-input-bucket/data/input1.txt"
-                path "s3://my-input-bucket/data/input2.txt"
-
+                  path "s3://my-input-bucket/data/input1.txt"
+                  path "s3://my-input-bucket/data/input2.txt"
 
                 """
                 echo "All input files are valid S3 paths."


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Fixes #43 

**Description of Changes**
Added a validation rule to the HealthOmics package to enforce `s3://` paths for all input and output file paths specified via the `path` directive.

**Description of how you validated changes**

Validation was performed by adding two test cases: one with valid `s3://` paths, which passed, and another with a local file path, which contains one violation as expected, demonstrating the rule's enforcement.

<br>

**Checklist**

- [X] If I have added a new rule, that rule has also been added to `healthomics-nextflow-rules/src/main/resources/rulesets/healthomics.xml`
- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have confirmed that I am able to locally build the project with no errors (`./gradlew clean build`)
- [X] I have not made extensive or unnecessary formatting changes unless this PR is specifically and only about reformatting
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*